### PR TITLE
Fix requirements conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file pins OpenCV below version 4.12 because newer
+releases require `numpy>=2`, while MediaPipe still depends on `numpy<2`.
+
 ## Running
 
 Run the main application:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-opencv-python>=4.12.0
+opencv-python<4.12
 mediapipe>=0.10.21
+numpy<2
 pillow
-pywin32
+pywin32; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- pin OpenCV below 4.12 so MediaPipe can use numpy 1.x
- mention numpy requirement in README

## Testing
- `python -m py_compile *.py`
- `python -m venv .venv && .venv/bin/pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6870d1d420c08333be6be8fb3ddc19c1