### PR TITLE
Add scroll mode indicator and fix stuck modifier key

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ A window will display the webcam feed with checkboxes to enable or disable gestu
 Swipe gestures control paging and a new scroll mode allows fine scrolling.
 To activate scroll mode hold an open palm (all five fingers) and then point
 your index finger toward the camera. Moving the finger up or down scrolls the
-foreground window.
+foreground window. When scroll mode is active the video feed is outlined in
+white so you know scrolling is enabled.

--- a/actions.py
+++ b/actions.py
@@ -31,6 +31,12 @@ def _press_combo(*keys: int) -> None:
         win32api.keybd_event(k, 0, win32con.KEYEVENTF_KEYUP, 0)
 
 
+def release_mod_keys() -> None:
+    """Release the Windows modifier key in case it remains pressed."""
+    MOD_WIN = 0x5B
+    win32api.keybd_event(MOD_WIN, 0, win32con.KEYEVENTF_KEYUP, 0)
+
+
 def dismiss_notifications() -> None:
     """Dismiss Windows notifications using Win+V then Esc."""
     MOD_WIN = 0x5B

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ class App(tk.Tk):
         self.update_frame()
 
     def _build_ui(self) -> None:
-        self.video_label = tk.Label(self)
+        self.video_label = tk.Label(self, bd=0, highlightthickness=0)
         self.video_label.pack()
         btn_frame = tk.Frame(self)
         btn_frame.pack()
@@ -48,6 +48,10 @@ class App(tk.Tk):
             imgtk = ImageTk.PhotoImage(image=img)
             self.video_label.imgtk = imgtk
             self.video_label.configure(image=imgtk)
+        if self.detector.scroll_mode:
+            self.video_label.configure(highlightbackground="white", highlightthickness=4)
+        else:
+            self.video_label.configure(highlightthickness=0)
         if gesture:
             self.handle_gesture(gesture)
         self.after(self.delay, self.update_frame)
@@ -74,7 +78,14 @@ class App(tk.Tk):
 
 if __name__ == "__main__":
     app = App()
-    app.protocol("WM_DELETE_WINDOW", lambda: (app.detector.release(), app.destroy()))
+    app.protocol(
+        "WM_DELETE_WINDOW",
+        lambda: (
+            actions.release_mod_keys(),
+            app.detector.release(),
+            app.destroy(),
+        ),
+    )
     app.mainloop()
 
 


### PR DESCRIPTION
## Summary
- indicate active scroll mode with a white border around the video feed
- prevent Windows modifier key from getting stuck
- document the new scroll indicator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870da472c808333a2d5c7097ede031a