### PR TITLE
Add global scroll overlay and hideable feed window

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ A window will display the webcam feed with checkboxes to enable or disable gestu
 Swipe gestures control paging and a new scroll mode allows fine scrolling.
 To activate scroll mode hold an open palm (all five fingers) and then point
 your index finger toward the camera. Moving the finger up or down scrolls the
-foreground window. When scroll mode is active the video feed is outlined in
-white so you know scrolling is enabled.
+foreground window. When scroll mode is active a white border appears around the
+entire screen so you know scrolling is enabled. You can hide the main window
+with the **Hide** button and gestures will continue to work in the background.


### PR DESCRIPTION
## Summary
- allow hiding the feed window so detection can run in the background
- draw the scroll-mode outline around the entire screen with a transparent overlay

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile actions.py detector.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6870e04829fc83339373784ba3d1fbcf